### PR TITLE
Add `--lib` option to the second `cargo new` invocation in ch14-03

### DIFF
--- a/second-edition/src/ch14-03-cargo-workspaces.md
+++ b/second-edition/src/ch14-03-cargo-workspaces.md
@@ -137,7 +137,7 @@ members = [
 それから、`add-one`という名前のライブラリクレートを生成してください:
 
 ```text
-$ cargo new add-one
+$ cargo new add-one --lib
      Created library `add-one` project
 ```
 


### PR DESCRIPTION
The default option for `cargo new` was changed from `--lib` to `--bin` in Cargo 0.26.0/Rust 1.25.0.

Fixes: #10