### PR TITLE
CIで使うmdBookを0.3.6へアップグレード

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:rust-1.41.0-mdbook-0.3.5
+      - image: quay.io/rust-lang-ja/circleci:mdbook-0.3.6-rust-1.41.0
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
CIで使うmdBookを0.3.5から0.3.6へアップグレードします（[CHANGELOG](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-036)）

0.3.6ではSUMMARYファイル内にHTMLコメントを書いたときにエラーになる件（ https://github.com/rust-lang/mdBook/pull/1167 ）など、いくつかの不具合の修正が施されています。

Rustは1.42.0がリリースされていますが、今回は1.41.0のまま変更しません。英語版bookリポジトリの [rust-toolchain](https://github.com/rust-lang/book/blob/a2bd349f8654f5c45ad1f07394225f946954b8ef/rust-toolchain) ファイルで1.41.0が指定されているため、それに合わせています。 

