### PR TITLE
second-editionから作成したブランチではCIをスキップする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ jobs:
         - second-edition-ja
     steps:
       - run:
-          name: Print error and exit
+          name: Print message and exit
           command: |
-            echo "ERROR: Wrong '.circleci/config' for $CIRCLE_BRANCH branch."
-            echo "       Please contact the developer (e.g. tatsuya6502) to fix."
-            exit 8
+            echo "NOTICE: Skipping CI on this $CIRCLE_BRANCH branch."


### PR DESCRIPTION
現在のCircle CIの設定で、second-editionブランチとmasterブランチから作成したトピックブランチでCIを実行すると、意図的にステータスコード8で失敗するようにしている。

しかし実際の運用ではCIを失敗させる必要はないので、スキップするように変更する。