### PR TITLE
ch04-03 - スライスのサンプルコードのアップデート（NLL対応）

### DIFF
--- a/second-edition/src/ch04-03-slices.md
+++ b/second-edition/src/ch04-03-slices.md
@@ -418,7 +418,7 @@ error[E0502]: cannot borrow `s` as mutable because it is also borrowed as immuta
   --> src/main.rs:18:5
    |
 16 |     let word = first_word(&s);
-   |                           -- immutable borrow occurs here
+   |                           -- immutable borrow occurs here (不変借用はここで発生しています)
 17 | 
 18 |     s.clear(); // error!        (エラー！)
    |     ^^^^^^^^^ mutable borrow occurs here (可変借用はここで発生しています)


### PR DESCRIPTION
#36 で報告された4章スライスの問題の対応。

借用エラーを発生させるためのサンプルコードがNLLではエラーにならなくなってしまったため、該当のコードを英語版の最新のものにアップデートします。（NLLは2018年12月リリースのRust 1.31で導入された）