### PR TITLE
付録D マクロの参考文献リンク（The Rust Reference）の修正

### DIFF
--- a/second-edition/src/appendix-04-macros.md
+++ b/second-edition/src/appendix-04-macros.md
@@ -225,7 +225,7 @@ macro_rules! vec {
 マクロのパターンは値ではなく、Rustコードの構造に対してマッチされるからです。リストD-1のパターンの部品がどんな意味か見ていきましょう;
 マクロパターン記法全ては[参考文献]をご覧ください。
 
-[参考文献]: ../../reference/macros.html
+[参考文献]: https://doc.rust-lang.org/reference/macros.html
 
 <!-- First, a set of parentheses encompasses the whole pattern. Next comes a dollar -->
 <!-- sign (`$`) followed by a set of parentheses, which captures values that match -->


### PR DESCRIPTION
#46 で報告された問題（公式サイトのドキュメントへのリンク切れ）の対応です。