### PR TITLE
ch08-01 リスト8-7のコードの修正

### DIFF
--- a/docs/ch08-01-vectors.html
+++ b/docs/ch08-01-vectors.html
@@ -425,6 +425,8 @@ work.
 let first = &amp;v[0];
 
 v.push(6);
+
+println!("The first element is: {}", first);
 </code></pre>
 <!--
 <span class="caption">Listing 8-7: Attempting to add an element to a vector

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -316,6 +316,8 @@ let mut v = vec![1, 2, 3, 4, 5];
 let first = &v[0];
 
 v.push(6);
+
+println!("The first element is: {}", first);
 ```
 
 <!--


### PR DESCRIPTION
表題通り，chapter08-01のリスト8-7のコードを修正しました．

原文では

```rust
let mut v = vec![1, 2, 3, 4, 5];

let first = &v[0];

v.push(6);

println!("The first element is: {}", first);
```

でしたが，日本語訳のものでは

```rust
let mut v = vec![1, 2, 3, 4, 5];

let first = &v[0];

v.push(6);
```

と最後の行が消えておりました．
そのため，このコードの下にあるコンパイルエラーが確認できない状態になっていました．
小さな修正ではありますが，ご確認お願いいたします．
