### PR TITLE
ch15-05 Fix typo (Second Edition)

### DIFF
--- a/second-edition/src/ch15-05-interior-mutability.md
+++ b/second-edition/src/ch15-05-interior-mutability.md
@@ -340,7 +340,7 @@ mod tests {
 <!-- <span class="caption">Listing 15-21: An attempt to implement a `MockMessenger` -->
 <!-- that isn’t allowed by the borrow checker</span> -->
 
-<span class="caption">リスト15-21: 借用チェッカーが許可してくれない`MockMessanger`を実装しようとする</span>
+<span class="caption">リスト15-21: 借用チェッカーが許可してくれない`MockMessenger`を実装しようとする</span>
 
 <!-- This test code defines a `MockMessenger` struct that has a `sent_messages` -->
 <!-- field with a `Vec` of `String` values to keep track of the messages it’s told -->


### PR DESCRIPTION
master-jaブランチ https://github.com/rust-lang-ja/book-ja/pull/79/ の修正をsecond-edition-jaブランチにも適用します。