### PR TITLE
ベクタの destroy の訳語を「破壊」から「破棄」へ

### DIFF
--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -201,7 +201,7 @@ value stored in a vector. In the examples, we’ve annotated the types of the
 values that are returned from these functions for extra clarity.
 -->
 
-もうベクタを生成し、更新し、破壊する方法を知ったので、中身を読む方法を知るのはいいステップアップです。
+もうベクタを生成し、更新し、破棄する方法を知ったので、中身を読む方法を知るのはいいステップアップです。
 ベクタに保持された値を参照する方法は2つあります。例では、さらなる明瞭性を求めて、
 これらの関数から返る値の型を注釈しました。
 


### PR DESCRIPTION
https://doc.rust-jp.rs/book-ja/ch08-01-vectors.html
において，

> もうベクタを生成し、更新し、破壊する方法を知ったので

とあります。原文は

> Now that you know how to create, update, and destroy vectors, 

です。

この「destory」は，ベクタがスコープを抜けて**捨てられる**ことを意味していると思いますので，「破壊」よりも「破棄」がふさわしいように思います。
（「破壊」だと，内容を変更することや，プログラムとしてマズイ状態にすることなどに誤解されそうです）