### PR TITLE
長方形の dimension の訳語を「次元」から「寸法」へ

### DIFF
--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -78,7 +78,7 @@ and the height are related to each other because together they describe one
 rectangle.
 -->
 
-リスト5-8のコードはうまく動き、各次元で`area`関数を呼び出すことで四角形の面積を割り出しますが、
+リスト5-8のコードはうまく動き、各寸法を与えて`area`関数を呼び出すことで四角形の面積を割り出しますが、
 改善点があります。幅と高さは、組み合わせると一つの四角形を表すので、相互に関係があるわけです。
 
 <!--

--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -99,7 +99,7 @@ manageable to group width and height together. We’ve already discussed one way
 we might do that in the "The Tuple Type" section of Chapter 3: by using tuples.
 -->
 
-`area`関数は、1の面積を求めるものと考えられますが、今書いた関数には、引数が2つあります。
+`area`関数は、1長方形の面積を求めるものと考えられますが、今書いた関数には、引数が2つあります。
 引数は関連性があるのに、このプログラム内のどこにもそのことは表現されていません。
 幅と高さを一緒にグループ化する方が、より読みやすく、扱いやすくなるでしょう。
 それをする一つの方法については、第3章の「タプル型」節ですでに議論しました: タプルを使うのです。

--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -275,7 +275,7 @@ of `rect2` are smaller than the dimensions of `rect1` but `rect3` is wider than
 `rect1`:
 -->
 
-そして、予期される出力は以下のようになります。なぜなら、`rect2`の各次元は`rect1`よりも小さいものの、
+そして、予期される出力は以下のようになります。なぜなら、`rect2`の各寸法は`rect1`よりも小さいものの、
 `rect3`は`rect1`より幅が広いからです:
 
 ```text
@@ -379,7 +379,7 @@ thus making it easier to create a square `Rectangle` rather than having to
 specify the same value twice:
 -->
 
-関連関数は、構造体の新規インスタンスを返すコンストラクタによく使用されます。例えば、一次元の引数を取り、
+関連関数は、構造体の新規インスタンスを返すコンストラクタによく使用されます。例えば、一つの寸法を引数に取り、
 長さと幅両方に使用する関連関数を提供することができ、その結果、同じ値を2回指定する必要なく、
 正方形の`Rectangle`を生成しやすくすることができます。
 


### PR DESCRIPTION
「dimension」を「次元」と訳したもののうち，以下の三箇所は「寸法」が適当であると思います。
長方形の幅・高さのことを表現していると思われるからです。

[1]
https://doc.rust-jp.rs/book-ja/ch05-02-example-structs.html

訳文：
> 各次元で`area`関数を呼び出すことで

原文：
> by calling the `area` function with each dimension

[2]
https://doc.rust-jp.rs/book-ja/ch05-03-method-syntax.html

訳文：
> `rect2`の各次元は`rect1`よりも小さいものの

原文：
> both dimensions of `rect2` are smaller than the dimensions of `rect1`

[3]
https://doc.rust-jp.rs/book-ja/ch05-03-method-syntax.html

訳文：
> 一次元の引数を取り

原文：
> would have one dimension parameter 

[1] の修正案では，「dimension ごとに関数を呼び出す」ように誤解されるのを避けるため，「各寸法を与えて」というように訳してみました。
[3] の修正案では，「一次元」を「一つの寸法」に修正しただけではまだ意味が取りにくいかと思い，「引数**に**取り」としてみました。