### PR TITLE
rectangle の訳語：「四角形」→「長方形」（その２）

### DIFF
--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -78,7 +78,7 @@ and the height are related to each other because together they describe one
 rectangle.
 -->
 
-リスト5-8のコードはうまく動き、各寸法を与えて`area`関数を呼び出すことで四角形の面積を割り出しますが、
+リスト5-8のコードはうまく動き、各寸法を与えて`area`関数を呼び出すことで長方形の面積を割り出しますが、
 改善点があります。幅と高さは、組み合わせると一つの長方形を表すので、相互に関係があるわけです。
 
 <!--


### PR DESCRIPTION
#101 と #103 をマージした後に「四角形」が一つ残ってしまったので、それを修正する。（[詳細](https://github.com/rust-lang-ja/book-ja/issues/100#issuecomment-706640618)）

----
Fixes: #100