### PR TITLE
第2版から最新版への誘導リンクの追加（その１）

### DIFF
--- a/second-edition/book.toml
+++ b/second-edition/book.toml
@@ -1,3 +1,6 @@
 [book]
 title = "The Rust Programming Language"
 author = "Steve Klabnik and Carol Nichols, with Contributions from the Rust Community"
+
+[output.html]
+additional-css = ["theme/notice.css"]

--- a/second-edition/theme/header.hbs
+++ b/second-edition/theme/header.hbs
@@ -1,0 +1,5 @@
+<blockquote class="header-notice">
+  <p>
+    <strong>注意: <a href="https://doc.rust-jp.rs/book-ja/">最新版のドキュメントをご覧ください。</a></strong>この第2版ドキュメントは古くなっており、最新情報が反映されていません。リンク先のドキュメントが現在の Rust の最新のドキュメントです。
+  </p>
+</blockquote>

--- a/second-edition/theme/notice.css
+++ b/second-edition/theme/notice.css
@@ -1,0 +1,29 @@
+.ayu .header-notice {
+    border-top: 1px solid #492b2d;
+    border-bottom: 1px solid #492b2d;
+    background-color: #492b2d;
+}
+
+.coal .header-notice {
+    border-top: 1px solid #552e28;
+    border-bottom: 1px solid #552e28;
+    background-color: #552e28;
+}
+
+.light .header-notice {
+    border-top: 1px solid #f0e1e1;
+    border-bottom: 1px solid #f0e1e1;
+    background-color: #f0e1e1;
+}
+
+.navy .header-notice {
+    border-top: 1px solid #492b2d;
+    border-bottom: 1px solid #492b2d;
+    background-color: #492b2d;
+}
+
+.rust .header-notice {
+    border-top: 1px solid #b9897f;
+    border-bottom: 1px solid #b9897f;
+    background-color: #b9897f;
+}


### PR DESCRIPTION
#88 の以下の項目についての対応。

> 最新版（2018 Edition）の公開後、第2版（second edition）の各ページに以下の内容を表示する。
>
>>    注意: 最新版のドキュメントをご覧ください。この第2版ドキュメントは古くなっており、最新情報が反映されていません。リンク先のドキュメントが現在の Rust の最新のドキュメントです。
