### PR TITLE
ch05-03 のリスト 5-14 のキャプションを修正

### DIFF
--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -267,7 +267,7 @@ fn main() {
 method</span>
 -->
 
-<span class="caption">リスト5-14: 未完成の`can_hold`を使用する</span>
+<span class="caption">リスト5-14: まだ書いていない`can_hold`メソッドを使用する</span>
 
 <!--
 And the expected output would look like the following, because both dimensions


### PR DESCRIPTION
ch05-03
https://doc.rust-jp.rs/book-ja/ch05-03-method-syntax.html
のリスト 5-14 のキャプションが

> リスト5-14: 未完成のcan_holdを使用する

となっています。原文は

> Listing 5-14: Using the as-yet-unwritten can_hold method

です。
`can_hold` メソッドは，この時点ではまだ 1 行も書いていないので，「未完成の」よりも「まだ書いていない」がふさわしいと思います。
また，原文では「`can_hold`」のあとに「method」とあるので，訳文でも「メソッド」を入れました。