### PR TITLE
ch05-02: use structs to add meaning ... の訳を改善

### DIFF
--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -183,7 +183,7 @@ we’re using into a data type with a name for the whole as well as names for th
 parts, as shown in Listing 5-10.
 -->
 
-データにラベル付けをして意味付けを行い、構造体を使います。現在使用しているタプルを全体と一部に名前のあるデータ型に、
+データのラベル付けで意味を付与するために構造体を使います。現在使用しているタプルを全体と一部に名前のあるデータ型に、
 変形することができます。そう、リスト5-10に示したように。
 
 <!--


### PR DESCRIPTION
ch05-02 の「構造体でリファクタリングする: より意味付けする」節の先頭に

> データにラベル付けをして意味付けを行い、構造体を使います。

とあります。
「意味付けを行う」と「構造体を使う」の関係が理解できませんでした。
原文は

> We use structs to add meaning by labeling the data. 

です。
この「to」は目的を表していると思いましたので，そのような修正の案を作ってみました。