### PR TITLE
ch10-02 angle brackets の訳：「角カッコ」→「山カッコ」

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -450,7 +450,7 @@ more verbose. We place trait bounds with the declaration of the generic type
 parameter after a colon and inside angle brackets.
 -->
 この「より長い」姿は前節の例と等価ですが、より冗長です。
-角カッコの中にジェネリックな型引数の宣言を書き、型引数の後ろにコロンを挟んでトレイト境界を置いています。
+山カッコの中にジェネリックな型引数の宣言を書き、型引数の後ろにコロンを挟んでトレイト境界を置いています。
 
 <!--
 The `impl Trait` syntax is convenient and makes for more concise code in simple


### PR DESCRIPTION
ch10-02 の「トレイト境界構文」節に

>  角カッコの中にジェネリックな型引数の宣言を書き

とあります。
「角カッコ」と訳されている箇所は原文では「angle brackets」なので，単純な誤訳のようです。

なお，括弧類については訳語の表記が「括弧」「カッコ」「かっこ」「波括弧」「角括弧」「山カッコ」「丸かっこ」「波かっこ」「角かっこ」「山かっこ」とバラバラです。
私見では漢字に統一するのがよいと思いますが，この PR では他に合わせて片仮名としました。