### PR TITLE
ch16-03: 技工→技巧

### DIFF
--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -107,7 +107,7 @@ many people are enthusiastic about channels. However, thanks to Rust’s type
 system and ownership rules, you can’t get locking and unlocking wrong.
 -->
 
-ミューテックスの管理は、正しく行うのに著しく技工を要することがあるので、多くの人がチャンネルに熱狂的になるわけです。
+ミューテックスの管理は、正しく行うのに著しく技巧を要することがあるので、多くの人がチャンネルに熱狂的になるわけです。
 しかしながら、Rustの型システムと所有権規則のおかげで、ロックとアンロックをおかしくすることはありません。
 
 <!--


### PR DESCRIPTION
ch16-03 に

> 正しく行うのに著しく技工を要することがある

というくだりがあります。原文は

> can be incredibly tricky to get right

で，「技工」は「技巧」の変換ミスと思われます。