### PR TITLE
ch11-01「pieces of Rust code」の「pieces」を「欠片」から「部品」に

### DIFF
--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -48,7 +48,7 @@ the functions annotated with the `test` attribute and reports on whether each
 test function passes or fails.
 -->
 最も単純には、Rustにおけるテストは`test`属性で注釈された関数のことです。属性とは、
-Rustコードの欠片に関するメタデータです; 一例を挙げれば、構造体とともに第5章で使用した`derive`属性です。
+Rustコードの部品に関するメタデータです; 一例を挙げれば、構造体とともに第5章で使用した`derive`属性です。
 関数をテスト関数に変えるには、`fn`の前に`#[test]`を付け加えてください。
 `cargo test`コマンドでテストを実行したら、コンパイラは`test`属性で注釈された関数を走らせるテスト用バイナリをビルドし、
 各テスト関数が通過したか失敗したかを報告します。


### PR DESCRIPTION
ch11-01
https://doc.rust-jp.rs/book-ja/ch11-01-writing-tests.html
に

> 属性とは、 Rustコードの欠片に関するメタデータです

という文があります。「欠片」の読みが分からなくて調べ，カケラだと分かりましたが，カケラは欠けて出来た小片であり，前提として「壊れた」のニュアンスを伴います。原文は

> Attributes are metadata about pieces of Rust code

です。この pieces は「部品」のほうがふさわしいと思いました。
（『ウィズダム英和辞典』に「2 (組み合わせるための)部品, パーツ, (ジグソーパズルの)1ピース」とあります）