### PR TITLE
ch10-2 タイポ修正: Trait -> Tweet

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -621,7 +621,7 @@ how to write a function with this behavior in the [“Using Trait Objects That
 Allow for Values of Different
 Types”][using-trait-objects-that-allow-for-values-of-different-types] section of Chapter 17.
 -->
-`NewsArticle`か`Trait`を返すというのは、コンパイラの`impl Trait`構文の実装まわりの制約により許されていません。
+`NewsArticle`か`Tweet`を返すというのは、コンパイラの`impl Trait`構文の実装まわりの制約により許されていません。
 このような振る舞いをする関数を書く方法は、17章の[トレイトオブジェクトで異なる型の値を許容する][using-trait-objects-that-allow-for-values-of-different-types]節で学びます。
 
 <!--


### PR DESCRIPTION
> 原文
> Returning either a `NewsArticle` or a `Tweet` isn’t allowed due to restrictions
>
> 日本語訳(修正前)
> `NewsArticle`か`Trait`を返すというのは...
> 日本語訳(修正後)
> `NewsArticle`か`Tweet`を返すというのは...

原文とコードから判断して、`Trait`を`Tweet`に修正しました。
ご確認お願いいたします。
