### PR TITLE
mdBook 0.4.5へアップグレード

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:mdbook-0.3.6-rust-1.41.0
+      - image: quay.io/rust-lang-ja/circleci:mdbook-0.4.5-rust-1.49.0
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
サイトの生成に使用しているmdBookのバージョンを0.3.6から0.4.5へアップデートします。理由は、0.4.5より前のバージョンで生成したサイトの検索機能にセキュリティーの脆弱性があるためです。

脆弱性の詳細：
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26297
- https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html

なお、mdBook 0.4.0〜0.4.5には `SUMMARY.md` 内にHTMLコメントがあるとサイトのビルドに失敗するという問題があります。そのため、当方にて修正したバージョンを使っています（[diff](https://github.com/rust-lang/mdBook/compare/master...rust-lang-ja:summary-with-html-comments)）　修正内容は、後日、mdBookのupstreamへpull requestを提出して、反映してもらう予定です。

