### PR TITLE
タイポ修正： リファクタリンク -> リファクタリング

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -157,7 +157,7 @@
 - [入出力プロジェクト：コマンドラインプログラムを構築する](ch12-00-an-io-project.md)
     - [コマンドライン引数を受け付ける](ch12-01-accepting-command-line-arguments.md)
     - [ファイルを読み込む](ch12-02-reading-a-file.md)
-    - [リファクタリンクしてモジュール性とエラー処理を向上させる](ch12-03-improving-error-handling-and-modularity.md)
+    - [リファクタリングしてモジュール性とエラー処理を向上させる](ch12-03-improving-error-handling-and-modularity.md)
     - [テスト駆動開発でライブラリの機能を開発する](ch12-04-testing-the-librarys-functionality.md)
     - [環境変数を取り扱う](ch12-05-working-with-environment-variables.md)
     - [標準出力ではなく標準エラーにエラーメッセージを書き込む](ch12-06-writing-to-stderr-instead-of-stdout.md)


### PR DESCRIPTION
- `SUMMARY.md` のセクション名にtypoがあったため修正しました。
  - リファクタリンク -> リファクタリング

`src/*.md`内で「リファクタリンク」を検索しましたが他にはありませんでした。
よろしくお願いいたします。