### PR TITLE
ch02-00の`io`型を`io`モジュールに、`stdin`関連関数を`stdin`関数に修正する

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -369,7 +369,7 @@ associated function, `stdin`, on `io`:
 -->
 
 プログラムの1行目で、`use std::io`として、標準ライブラリから入/出力機能を取り込んだことを思い出してください。
-今度は、`io`型の`stdin`関連関数を呼び出しましょう:
+今度は、`io`モジュールの`stdin`関数を呼び出しましょう:
 
 ```rust,ignore
 io::stdin().read_line(&mut guess)


### PR DESCRIPTION
372行目の「`io`型」あるのは「`io`モジュール」とすべきではないのでしょうか。`std::io`はモジュールであって型ではないので修正した方がよいと思います。（Rustにおける型の定義は https://doc.rust-lang.org/reference/types.html を参照してください。）
https://github.com/rust-lang-ja/book-ja/blob/dc86b59faab91a43590fc48a626217acc5fb43c5/src/ch02-00-guessing-game-tutorial.md#L372

原文では単に`io`とあるだけですが、`stdin`はassociated functionという言葉で修飾されています。おそらくこれに引っ張られたのだと思います。そして、[関連関数は型に関連付けられた関数のことをいう](https://doc.rust-lang.org/reference/items/associated-items.html#associated-functions-and-methods)ので原文が誤っているのかもしれません。

https://github.com/rust-lang-ja/book-ja/blob/dc86b59faab91a43590fc48a626217acc5fb43c5/src/ch02-00-guessing-game-tutorial.md#L365-L369
