### PR TITLE
Fix command to set toolchain

### DIFF
--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -318,7 +318,7 @@ nightly toolchain as the one `rustup` should use when you’re in that directory
 
 ```text
 $ cd ~/projects/needs-nightly
-$ rustup override add nightly
+$ rustup override set nightly
 ```
 
 <!--


### PR DESCRIPTION
こんにちは。
誤りを見つけたので修正しました。
確認をお願いできますでしょうか？

# 変更について
`rustup override` のサブコマンド `add` は `set` にリネームされたようです。
下位互換性のために `add` でも動作はするようですが、ヘルプには `add` の記載がありません。

```
$ rustup override -h
rustup-override 
Modify directory toolchain overrides

USAGE:
    rustup override <SUBCOMMAND>

FLAGS:
    -h, --help    Prints help information

SUBCOMMANDS:
    list     List directory toolchain overrides
    set      Set the override toolchain for a directory
    unset    Remove the override toolchain for a directory
    help     Prints this message or the help of the given subcommand(s)
```

原本でも修正済みのようです：
https://github.com/rust-lang/book/commit/de99df4c9f729afd11a886381bd9c0bd5a102b16