### PR TITLE
Fix chapter 19 for macros

### DIFF
--- a/src/ch19-00-advanced-features.md
+++ b/src/ch19-00-advanced-features.md
@@ -34,6 +34,7 @@ syntax, supertraits, and the newtype pattern in relation to traits
 * Advanced types: more about the newtype pattern, type aliases, the never type,
 and dynamically sized types
 * Advanced functions and closures: function pointers and returning closures
+* Macros: ways to define code that defines more code at compile time
 -->
 
 * Unsafe Rust: Rustの保証の一部を抜けてその保証を手動で保持する責任を負う方法
@@ -41,6 +42,7 @@ and dynamically sized types
 * 高度なトレイト: 関連型、デフォルト型引数、フルパス記法、スーパートレイト、トレイトに関連するニュータイプパターン
 * 高度な型: ニュータイプパターンについてもっと、型エイリアス、never型、動的サイズ決定型
 * 高度な関数とクロージャ: 関数ポインタとクロージャの返却
+* マクロ: コンパイル時に、より多くのコードを定義するコードを定義する方法
 
 <!--
 It’s a panoply of Rust features with something for everyone! Let’s dive in!

--- a/src/ch19-05-advanced-functions-and-closures.md
+++ b/src/ch19-05-advanced-functions-and-closures.md
@@ -239,27 +239,7 @@ Chapter 17.
 第17章の「トレイトオブジェクトで異なる型の値を許容する」節を参照してください。
 
 <!--
-## Summary
+Next, let’s look at macros!
 -->
 
-## まとめ
-
-<!--
-Whew! Now you have some features of Rust in your toolbox that you won’t use
-often, but you’ll know they’re available in very particular circumstances.
-We’ve introduced several complex topics so that when you encounter them in
-error message suggestions or in other peoples’ code, you’ll be able to
-recognize these concepts and syntax. Use this chapter as a reference to guide
-you to solutions.
--->
-
-ふう！もう道具箱に頻繁には使用しないRustの機能の一部がありますが、非常に限定された状況で利用可能だと知るでしょう。
-エラーメッセージや他の方のコードで遭遇した際に、これらの概念や記法を認識できるように、
-複雑な話題をいくつか紹介しました。この章は、解決策へ導く参考文献としてご活用ください。
-
-<!--
-Next, we’ll put everything we’ve discussed throughout the book into practice
-and do one more project!
--->
-
-次は、本を通して議論してきた全てを実践に配備し、もう1つプロジェクトを<ruby>熟<rp>(</rp><rt>こな</rt><rp>)</rp></ruby>します！
+次は、マクロを見てみましょう！


### PR DESCRIPTION
こんにちは。
誤りを見つけたので修正しました。
確認をお願いできますでしょうか？

# 変更について
Chapter 19.5が後から追加されたのか、Chapter 19.4の締めくくりがChapter 20に進む旨の文章になってしまっているので修正しました。関連してChapter 19で説明される機能のリストにマクロに関する説明を追加しました。

# 余談
Chapter 19はファイル名のナンバリングが途中からずれているみたいですね。説明のナンバリングと変更しているファイルのナンバリングがずれているのでご注意ください。

`ch19-05-advanced-functions-and-closures.md` はChapter 19.4です。