### PR TITLE
Tweak a sentence  in ch04-03-slices

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -236,7 +236,7 @@ a slice that contains a pointer to the 7th byte (counting from 1) of `s` with a 
 ここで、`starting_index`はスライスの最初の位置、`ending_index`はスライスの終端位置よりも、
 1大きい値です。内部的には、スライスデータ構造は、開始地点とスライスの長さを保持しており、
 スライスの長さは`ending_index`から`starting_index`を引いたものに対応します。以上より、
-`let world = &s[6..11];`の場合には、`world`は`s`の（1から数えて）7バイト目へのポインタと5という長さを保持するスライスになるでしょう。
+`let world = &s[6..11];`の場合には、`world`は`s`の添え字6のバイトへのポインタと5という長さを持つスライスになるでしょう。
 
 <!--
 Figure 4-6 shows this in a diagram.


### PR DESCRIPTION
1から数えると指折り6になります。
https://doc.rust-jp.rs/book-ja/ch04-03-slices.html の図4-6 が同様に示す、"world" の ptr が参照する先の数とも一致するようになります。

また、6にすることで原文が示す以下の数字とも一致するようになります。

> So in the case of `let world = &s[6..11];`, world would be a slice that
> contains a pointer to the byte at index 6 of `s` with a length value of 5.

https://doc.rust-lang.org/stable/book/ch04-03-slices.html#string-slices