### PR TITLE
タイトルページのアップデートとmdbookの設定変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: rustc -V
       - run: mdbook -V
       - run: mdbook test
-      - run: mdbook build
+      - run: mdbook build --dist-dir docs
       - run: cargo run --bin lfp src
       # TODO: Run link2print here. (See ci/build.sh on the master branch)
       # - run: TODO

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: rustc -V
       - run: mdbook -V
       - run: mdbook test
-      - run: mdbook build --dist-dir docs
+      - run: mdbook build --dest-dir docs
       - run: cargo run --bin lfp src
       # TODO: Run link2print here. (See ci/build.sh on the master branch)
       # - run: TODO

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ book/
 .DS_Store
 target
 tmp
-

--- a/book.toml
+++ b/book.toml
@@ -3,9 +3,6 @@ title = "The Rust Programming Language 日本語版"
 author = "Steve Klabnik and Carol Nichols, with Contributions from the Rust Community"
 language = "ja"
 
-[build]
-build-dir = "docs"
-
 [output.html]
 additional-css = ["ferris.css", "theme/2018-edition.css", "theme/em-to-bold.css"]
 additional-js = ["ferris.js"]

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -6,62 +6,15 @@
 <!--
 *by Steve Klabnik and Carol Nichols, with contributions from the Rust Community*
 -->
-*著：Steve Klabnik, Carol Nichols, 貢献：Rustコミュニティ*
+*著：Steve Klabnik、Carol Nichols、貢献：Rustコミュニティ*
 
 <!--
-This version of the text assumes you’re using Rust 1.41.0 or later with
-`edition="2018"` in *Cargo.toml* of all projects to use Rust 2018 Edition
-idioms. See the [“Installation” section of Chapter 1][install]
-to install or update Rust, and see the new [Appendix E][editions]
-for information on editions.
+This version of the text assumes you’re using Rust 1.58 (released 2022-01-13)
+or later. See the [“Installation” section of Chapter 1][install]
+to install or update Rust.
 -->
-このテキストのこの版では、Rust 2018 Editionのイディオムを使うため、Rust 1.41.0かそれ以降を使っており、すべてのプロジェクトの *Cargo.toml* に `edition="2018"` とあることを前提にしています。
-Rustをインストールしたりアップデートするには[1章の「インストール」節][install]を、editionに関しては[付録E][editions]を読んでください。
-
-<!--
-The 2018 Edition of the Rust language includes a number of improvements that
-make Rust more ergonomic and easier to learn. This iteration of the book
-contains a number of changes to reflect those improvements:
--->
-Rust言語の2018 Editionには、Rustをもっと扱いやすく、学びやすくするための多くの改善点があります。
-それらの改善点を反映するために、今回の改版は多くの変更点を含んでいます：
-
-<!--
-- Chapter 7, “Managing Growing Projects with Packages, Crates, and Modules,”
-  has been mostly rewritten. The module system and the way paths work in the
-  2018 Edition were made more consistent.
-- Chapter 10 has new sections titled “Traits as Parameters” and “Returning
-  Types that Implement Traits” that explain the new `impl Trait` syntax.
-- Chapter 11 has a new section titled “Using `Result<T, E>` in Tests” that
-  shows how to write tests that use the `?` operator.
-- The “Advanced Lifetimes” section in Chapter 19 was removed because compiler
-  improvements have made the constructs in that section even rarer.
-- The previous Appendix D, “Macros,” has been expanded to include procedural
-  macros and was moved to the “Macros” section in Chapter 19.
-- Appendix A, “Keywords,” also explains the new raw identifiers feature that
-  enables code written in the 2015 Edition and the 2018 Edition to interoperate.
-- Appendix D is now titled “Useful Development Tools” and covers recently
-  released tools that help you write Rust code.
-- We fixed a number of small errors and imprecise wording throughout the book.
-  Thank you to the readers who reported them!
--->
-- 7章「肥大化していくプロジェクトをパッケージ、クレート、モジュールを利用して管理する」はほとんど書き直されました。2018 Editionにおいてモジュールシステムとパスの仕組みはより一貫性を持つようになりました。
-- 10章には、新しい`impl Trait`構文を説明するために「引数としてのトレイト」と「トレイトを実装している型を返す」という新しい節があります。
-- 11章には、`?`演算子を使うテストの書き方を説明する「`Result<T, E>`をテストで使う」という新しい節があります。
-- 19章の「高度なライフタイム」節はなくなりました。コンパイラの改善により、この節の内容が現れることはいっそう稀になったからです。
-- 付録D「マクロ」は、手続き的マクロも説明するようになり、19章の「マクロ」節に移動しました。
-- 付録A「キーワード」では、2015 Editionと2018 Editionで書かれたコードを一緒に使えるようにしてくれる、生識別子という新しい機能も説明します。
-- 付録Dは "Useful Development Tools" という名前に変わり、Rustコードを書く手助けになる最近登場したツールを説明します。
-- 多くの細かい誤りや不正確な言葉遣いを直しました。報告してくれた読者の皆様、ありがとうございます！
-
-<!--
-Note that any code in earlier iterations of *The Rust Programming Language*
-that compiled will continue to compile without `edition="2018"` in the
-project’s *Cargo.toml*, even as you update the Rust compiler version you’re
-using. That’s Rust’s backward compatibility guarantees at work!
--->
-`edition="2018"` を *Cargo.toml* に書かなければ、Rustコンパイラのバージョンをアップデートしたとしても、 *The Rust Programming Language* のこれまでの版のコードは変わらずコンパイルできるということを知っておいてください。
-Rustの後方互換性の約束は守られています！
+このテキストのこの版ではRust 1.58（2022年1月13日リリース）かそれ以降が使われていることを前提にしています。
+Rustをインストールしたりアップデートしたりするには[第1章の「インストール」節][install]を読んでください。
 
 <!--
 The HTML format is available online at
@@ -70,14 +23,24 @@ and offline with installations of Rust made with `rustup`; run `rustup docs
 --book` to open.
 -->
 HTML版は[https://doc.rust-lang.org/stable/book/](https://doc.rust-lang.org/stable/book/)で公開されています。
-オフラインで見たい場合は、`rustup`でインストールしたRustを使って`rustup docs --book`としてください。
+オフラインのときは、`rustup`でインストールしたRustを使って`rustup docs --book`で開けます。
+
+> 訳注：日本語のHTML版は[https://doc.rust-jp.rs/book-ja/](https://doc.rust-jp.rs/book-ja/)で公開されています。
+> `rustup`を使ってオフラインで読むことはできません。
+
+<!--
+Several community [translations] are also available.
+-->
+また、コミュニティによるいくつかの[翻訳版][translations]もあります。
 
 <!--
 This text is available in [paperback and ebook format from No Starch
 Press][nsprust].
 -->
-このテキストの[ペーパーバック版と電子書籍版はNo Starch出版][nsprust]から発売されています。
+このテキストの（英語版の）[ペーパーバック版と電子書籍版はNo Starch出版][nsprust]から発売されています。
+
 
 [install]: ch01-01-installation.html
 [editions]: appendix-05-editions.html
 [nsprust]: https://nostarch.com/rust
+[translations]: appendix-06-translation.html


### PR DESCRIPTION
- タイトルページを最新の内容にアップデートしました
- mdbookの設定を変更して、ローカルでビルドしたときはHTMLが`book`ディレクトリーに出力されるようにしました
    - いままでは`docs`ディレクトリーに出力されていた
    - Circle CIではいままでどおり`docs`ディレクトリーに出力する

* * *
Fixes #183 