### PR TITLE
付録E：エディションを最新版にアップデート

### DIFF
--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -71,6 +71,7 @@
 | documentation comment          | ドキュメンテーションコメント
 | documentation test             | ドキュメンテーションテスト
 | early return                   | 早期リターン
+| edition                        | エディション
 | empty tuple                    | 空タプル
 | encode                         | エンコード
 | entry point                    | エントリポイント

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -293,6 +293,6 @@
     - [付録B：演算子と記号](appendix-02-operators.md)
     - [付録C：導出可能なトレイト](appendix-03-derivable-traits.md)
     - [付録D：便利な開発ツール](appendix-04-useful-development-tools.md)
-    - [付録E：Edition](appendix-05-editions.md)
+    - [付録E：エディション](appendix-05-editions.md)
     - [付録F：本の翻訳](appendix-06-translation.md)
     - [付録G：Rustの作られ方と“Nightly Rust”](appendix-07-nightly-rust.md)

--- a/src/appendix-05-editions.md
+++ b/src/appendix-05-editions.md
@@ -18,7 +18,7 @@ while, all of these tiny changes add up. But from release to release, it can be
 difficult to look back and say, “Wow, between Rust 1.10 and Rust 1.31, Rust has
 changed a lot!”
 -->
-Rust言語とコンパイラは6週間のリリースサイクルを採用しています。つまり、ユーザーにはコンスタントに新しい機能が流れてくるというわけです。
+Rust言語とコンパイラは6週間のリリースサイクルを採用しています。つまり、ユーザにはコンスタントに新しい機能が流れてくるというわけです。
 他のプログラミング言語は、より少ない回数で、より大きなリリースを行いますが、Rustは小さなアップデートを頻繁に行います。
 しばらくすると、これらの小さな変更が溜まっていきます。
 しかし、これらを振り返って、「Rust 1.10とRust 1.31を比較すると、すごく変わったねえ！」などとリリースごとに言うのは難しいです。

--- a/src/appendix-05-editions.md
+++ b/src/appendix-05-editions.md
@@ -1,13 +1,13 @@
 <!--
 ## Appendix E - Editions
 -->
-## 付録E - Edition
+## 付録E：エディション
 
 <!--
 In Chapter 1, you saw that `cargo new` adds a bit of metadata to your
 *Cargo.toml* file about an edition. This appendix talks about what that means!
 -->
-1章で、`cargo new`がeditionに関するちょっとしたメタデータを *Cargo.toml* に追加しているのを見ましたね。
+第1章で、`cargo new`が エディションに関するちょっとしたメタデータを *Cargo.toml* に追加しているのを見ましたね。
 この付録ではその意味についてお話します！
 
 <!--
@@ -19,7 +19,7 @@ difficult to look back and say, “Wow, between Rust 1.10 and Rust 1.31, Rust ha
 changed a lot!”
 -->
 Rust言語とコンパイラは6週間のリリースサイクルを採用しています。つまり、ユーザーにはコンスタントに新しい機能が流れてくるというわけです。
-他のプログラミング言語は、より少ない回数、より大きなリリースを行いますが、Rustは小さなアップデートをより頻繁に行います。
+他のプログラミング言語は、より少ない回数で、より大きなリリースを行いますが、Rustは小さなアップデートを頻繁に行います。
 しばらくすると、これらの小さな変更が溜まっていきます。
 しかし、これらを振り返って、「Rust 1.10とRust 1.31を比較すると、すごく変わったねえ！」などとリリースごとに言うのは難しいです。
 
@@ -29,14 +29,14 @@ edition brings together the features that have landed into a clear package with
 fully updated documentation and tooling. New editions ship as part of the usual
 six-week release process.
 -->
-2、3年ごとに、RustチームはRustの新しい *edition* を作ります。
-それぞれのeditionには、それまでにRustにやってきた新しい機能が、完全に更新されたドキュメントとツール群とともに、まとまったパッケージとなってまとめられています。
-新しいeditionは通常の6週間ごとのリリースの一部として配布されます。
+2、3年ごとに、RustチームはRustの新しい *エディション* を作ります。
+それぞれのエディションには、それまでにRustにやってきた新しい機能が、完全に更新されたドキュメントとツール群とともに、一つのパッケージとなってまとめられています。
+新しいエディションは通常の6週間ごとのリリースの一部として配布されます。
 
 <!--
 Editions serve different purposes for different people:
 -->
-それぞれの人々にとってeditionは異なる意味を持ちます：
+それぞれの人々にとってエディションは異なる意味を持ちます。
 
 <!--
 * For active Rust users, a new edition brings together incremental changes into
@@ -46,16 +46,17 @@ Editions serve different purposes for different people:
 * For those developing Rust, a new edition provides a rallying point for the
   project as a whole.
 -->
-* アクティブなRustユーザにとっては、新しいeditionは、少しずつ増えてきた変更点を理解しやすいパッケージにしてまとめるものです。
-* Rustユーザでない人にとっては、新しいeditionは、何かしら大きな達成がなされたことを示します。Rustには今一度目を向ける価値があると感じさせるかもしれません。
-* Rustを開発している人にとっては、新しいeditionは、プロジェクト全体の目標地点となります。
+* アクティブなRustユーザにとっては、新しいエディションは、少しずつ増えてきた変更点を理解しやすいパッケージにしてまとめるものです。
+* Rustユーザでない人にとっては、新しいエディションは、何かしら大きな達成がなされたことを示します。Rustには今一度目を向ける価値があると感じさせるかもしれません。
+* Rustを開発している人にとっては、新しいエディションは、プロジェクト全体の目標地点となります。
 
 <!--
-At the time of this writing, two Rust editions are available: Rust 2015 and
-Rust 2018. This book is written using Rust 2018 edition idioms.
+At the time of this writing, three Rust editions are available: Rust 2015, Rust
+2018, and Rust 2021. This book is written using Rust 2021 edition idioms.
 -->
-この文書を書いている時点（訳注：原文のコミットは2019-03-01）では、2つのRustのeditionが利用できます：Rust 2015とRust 2018です。
-この本はRust 2018の慣例に従って書かれています。
+この文書を書いている時点（訳注：原文のコミットは2021年12月23日）では、3つのRustのエディションが利用できます。
+Rust 2015、Rust 2018、Rest 2021です。
+この本はRust 2021エディションの慣例に従って書かれています。
 
 <!--
 The `edition` key in *Cargo.toml* indicates which edition the compiler should
@@ -63,7 +64,7 @@ use for your code. If the key doesn’t exist, Rust uses `2015` as the edition
 value for backward compatibility reasons.
 -->
 *Cargo.toml* における`edition`キーは、コードに対してコンパイラがどのエディションを適用すべきかを示しています。
-もしキーが存在しなければ、Rustは後方互換性のため`2015`をeditionの値として使います。
+もしキーが存在しなければ、Rustは後方互換性のため`2015`をエディションの値として使います。
 
 <!--
 Each project can opt in to an edition other than the default 2015 edition.
@@ -72,8 +73,8 @@ conflicts with identifiers in code. However, unless you opt in to those
 changes, your code will continue to compile even as you upgrade the Rust
 compiler version you use.
 -->
-標準の2015 edition以外のeditionを使うという選択はそれぞれのプロジェクトですることができます。
-editionには、コード内の識別子と衝突してしまう新しいキーワードの導入など、互換性のない変更が含まれる可能性があります。
+標準の2015エディション以外のエディションを使うという選択はそれぞれのプロジェクトですることができます。
+エディションには、コード内の識別子と衝突してしまう新しいキーワードの導入など、互換性のない変更が含まれる可能性があります。
 しかし、それらの変更を選択しない限り、Rustのコンパイラのバージョンを更新しても、コードは変わらずコンパイルできます。
 
 <!--
@@ -85,8 +86,8 @@ Rust 2018, your project will compile and be able to use that dependency. The
 opposite situation, where your project uses Rust 2018 and a dependency uses
 Rust 2015, works as well.
 -->
-Rustコンパイラは全バージョンにおいて、そのコンパイラのリリースまでに存在したすべてのeditionをサポートしており、またサポートされているeditionのクレートはすべてリンクできます。
-editionの変更はコンパイラが最初にコードを構文解析するときにのみ影響します。
+Rustコンパイラは全バージョンにおいて、そのコンパイラのリリースまでに存在したすべてのエディションをサポートしており、またサポートされているエディションのクレートはすべてリンクできます。
+エディションの変更はコンパイラが最初にコードを構文解析するときにのみ影響します。
 なので、あなたがRust 2015を使っていて、依存先にRust 2018を使うものがあったとしても、あなたのプロジェクトはコンパイルでき、その依存先を使うことができます。
 逆に、あなたのプロジェクトがRust 2018を、依存先がRust 2015を使っていても、同じく問題はありません。
 
@@ -97,10 +98,10 @@ made. However, in some cases, mainly when new keywords are added, some new
 features might only be available in later editions. You will need to switch
 editions if you want to take advantage of such features.
 -->
-まあ実のところ、ほとんどの機能はすべてのeditionで利用可能でしょう。
-どのRust editionを使っている開発者も、新しい安定リリースが出ると、改善したなと感じるのは変わらないでしょう。
-しかし、場合によっては――多くは新しいキーワードが追加された時――新機能が新しいeditionでしか利用できないということがあるかもしれません。
-そのような機能を利用したいなら、editionを切り替える必要があるでしょう。
+まあ実のところ、ほとんどの機能はすべてのエディションで利用可能でしょう。
+どのRustエディションを使っている開発者も、新しい安定リリースが出ると改善したなと感じるのは変わらないでしょう。
+しかし、場合によって（多くは新しいキーワードが追加されたとき）は、新機能が新しいエディションでしか利用できないことがあるかもしれません。
+そのような機能を利用したいなら、エディションを切り替える必要があるでしょう。
 
 <!--
 For more details, the [*Edition
@@ -108,4 +109,7 @@ Guide*](https://doc.rust-lang.org/stable/edition-guide/) is a complete book
 about editions that enumerates the differences between editions and explains
 how to automatically upgrade your code to a new edition via `cargo fix`.
 -->
-より詳しく知りたいなら、[*Editionガイド*](https://doc.rust-lang.org/stable/edition-guide/) という、editionに関するすべてを説明している本があります。edition同士の違いや、`cargo fix`を使って自動的にコードを新しいeditionにアップグレードする方法が書かれています。
+より詳しく知りたいなら、[*エディションガイド*](https://doc.rust-lang.org/stable/edition-guide/)という、エディションに関するすべてを説明している本があります。
+エディション同士の違いや、`cargo fix`を使って自動的にコードを新しいエディションにアップグレードする方法が書かれています。
+
+> 訳注：日本語版のエディションガイドは[こちら](https://doc.rust-jp.rs/edition-guide/)にあります。


### PR DESCRIPTION
- 付録E：エディションを最新版にアップデート
- Editionの訳語を（[エディションガイド](https://doc.rust-jp.rs/edition-guide/)に合わせ）「edition」から「エディション」へ変更 

* * *
Fixes #184 