### PR TITLE
READMEのリンクを修正

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -71,7 +71,7 @@ $ mdbook test
 We'd love your help! Please see [CONTRIBUTING.md][contrib] to learn about the
 kinds of contributions we're looking for.
 
-[contrib]: https://github.com/rust-lang/book/blob/master/CONTRIBUTING.md
+[contrib]: https://github.com/rust-lang/book/blob/main/CONTRIBUTING.md
 
 ### Translations
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ mdbook test
 We'd love your help! Please see [CONTRIBUTING.md][contrib] to learn about the
 kinds of contributions we're looking for.
 
-[contrib]: https://github.com/rust-lang/book/blob/master/CONTRIBUTING.md
+[contrib]: https://github.com/rust-lang/book/blob/main/CONTRIBUTING.md
 
 ### Translations
 


### PR DESCRIPTION
`README.md`, `README-en.md` 内のリンクを修正しました。
- [rust-lang/book](https://github.com/rust-lang/book/) のブランチを main へと修正