### PR TITLE
CIで使用するDockerイメージを最新の`mdbook`イメージに変更する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:mdbook-0.4.8-rust-1.49.0
+      - image: quay.io/rust-lang-ja/circleci:mdbook
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
Circle CIで使用するDockerイメージを、特定のmdBookバージョンに固定したものから、最新のものに変更します。

- 変更前：`quay.io/rust-lang-ja/circleci:mdbook-0.4.8-rust-1.49.0`
- 変更後：`quay.io/rust-lang-ja/circleci:mdbook`