### PR TITLE
fix ch03-03 print_labeled_measurement explanation

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -171,15 +171,15 @@ declarations with commas, like this:
 ```
 
 <!--
-This example creates a function with two parameters, both of which are `i32`
-types. The function then prints the values in both of its parameters. Note that
-function parameters don't all need to be the same type, they just happen to be
-in this example.
+This example creates a function named `print_labeled_measurement` with two
+parameters. The first parameter is named `value` and is an `i32`. The second is
+named `unit_label` and is type `char`. The function then prints text containing
+both the `value` and the `unit_label`.
 -->
 
-この例では、2引数の関数を生成しています。そして、引数はどちらも`i32`型です。それからこの関数は、
-仮引数の値を両方出力します。関数引数は、全てが同じ型である必要はありません。今回は、
-偶然同じになっただけです。
+この例では、`print_labeled_measurement`という名前で2引数の関数を生成しています。
+1つめの仮引数は`name`という名前で`i32`型です。2つめの仮引数は`unit_label`という名前で`char`型です。
+この関数は`value`と`unit_label`の両方を含むテキストを出力します。
 
 <!--
 Let’s try running this code. Replace the program currently in your *functions*
@@ -195,12 +195,12 @@ run`:
 ```
 
 <!--
-Because we called the function with `5` as the value for `x` and `6` is passed
-as the value for `y`, the two strings are printed with these values.
+Because we called the function with `5` as the value for `value` and `'h'` as
+the value for `unit_label`, the program output contains those values.
 -->
 
-`x`に対して値`5`、`y`に対して値`6`を渡して関数を呼び出したので、この二つの文字列は、
-この値で出力されました。
+`value`に対して`5`、`unit_label`に対して`'h'`を渡して関数を呼び出したので、
+プログラムの出力にはそれらの値が含まれています。
 
 <!--
 NOTE: doc.rust-lang.orgのものではヘッダが変わっている


### PR DESCRIPTION
## 内容

ch03-03

関数`print_labeled_measurement`のコードと説明の不一致を修正

## 関連

* https://github.com/rust-lang-ja/book-ja/pull/194
* https://github.com/rust-lang/book/blob/0a5421ceb238357b3634fb75234eba4d1dad643c/src/ch03-03-how-functions-work.md?plain=1#L85-L100
