### PR TITLE
14.2 の軽微な修正

### DIFF
--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -73,9 +73,10 @@ for an `add_one` function in a crate named `my_crate`:
 /// # Examples
 ///
 /// ```
-/// let five = 5;
+/// let arg = 5;
+/// let answer = my_crate::add_one(arg);
 ///
-/// assert_eq!(6, my_crate::add_one(5));
+/// assert_eq!(6, answer);
 /// ```
 pub fn add_one(x: i32) -> i32 {
     x + 1

--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -410,7 +410,7 @@ pub mod kinds {
 }
 
 pub mod utils {
-    use kinds::*;
+    use crate::kinds::*;
 
     /// Combines two primary colors in equal amounts to create
     /// a secondary color.


### PR DESCRIPTION
# 変更内容
- リスト14-1のコードを修正
  - コードと図14-1の内容が一致していなかったため
- リスト14-3 の use 文を修正
  - `use kinds::*;` だと下記エラーが発生したため。[原著](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#exporting-a-convenient-public-api-with-pub-use)は `use crate::kinds::*;` となっている

```bash
$ cargo run
   Compiling my_crate v0.1.0 (/Users/<username>/programing/rust/my_crate)
error[E0432]: unresolved import `kinds`
  --> src/lib.rs:22:9
   |
22 |     use kinds::*;
   |         ^^^^^ help: a similar path exists: `crate::kinds`
   |
   = note: `use` statements changed in Rust 2018; read more at <https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html>
```