### PR TITLE
Fix inconsistency between code and description in ch03-03

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -171,15 +171,15 @@ declarations with commas, like this:
 ```
 
 <!--
-This example creates a function with two parameters, both of which are `i32`
-types. The function then prints the values in both of its parameters. Note that
-function parameters don't all need to be the same type, they just happen to be
-in this example.
+This example creates a function named `print_labeled_measurement` with two
+parameters. The first parameter is named `value` and is an `i32`. The second is
+named `unit_label` and is type `char`. The function then prints text containing
+both the `value` and the `unit_label`.
 -->
 
-この例では、2引数の関数を生成しています。そして、引数はどちらも`i32`型です。それからこの関数は、
-仮引数の値を両方出力します。関数引数は、全てが同じ型である必要はありません。今回は、
-偶然同じになっただけです。
+この例では、`print_labeled_measurement`という名前の関数を2つの仮引数で作成します。
+最初の仮引数は`value`で、`i32`型です。2番目の仮引数は`unit_label`で、`char`型です。
+この関数は`value`と`unit_label`の両方を含む文字列を表示します。
 
 <!--
 Let’s try running this code. Replace the program currently in your *functions*


### PR DESCRIPTION
Corrected the explanation where there is a discrepancy between the code example and its description in Chapter 3.3. Below is the code in question.

[../listings/ch03-common-programming-concepts/no-listing-18-functions-with-multiple-parameters/src/main.rs](https://github.com/rust-lang-ja/book-ja/blob/master-ja/listings/ch03-common-programming-concepts/no-listing-18-functions-with-multiple-parameters/src/main.rs)

```Rust
fn print_labeled_measurement(value: i32, unit_label: char) {
    println!("The measurement is: {}{}", value, unit_label);
}
```