### PR TITLE
fix broken url

### DIFF
--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -487,5 +487,5 @@ collection type: `String`!
 
 [data-types]: ch03-02-data-types.html#データ型
 [nomicon]: ../nomicon/vec.html
-[vec-api]: ../std/vec/struct.Vec.html
+[vec-api]: https://doc.rust-lang.org/std/vec/struct.Vec.html
 [deref]: ch15-02-deref.html#参照外し演算子で値までポインタを追いかける


### PR DESCRIPTION
[ベクタで値のリストを保持する](https://doc.rust-jp.rs/book-ja/ch08-01-vectors.html)ページの `Vec<T>`のAPIドキュメントのリンクが切れていたため、[英語版](https://doc.rust-lang.org/book/ch08-01-vectors.html)と同じURLに遷移するようにしました。


