### PR TITLE
Unified translation of zero-cost abstractions

### DIFF
--- a/src/ch13-04-performance.md
+++ b/src/ch13-04-performance.md
@@ -164,7 +164,7 @@ Rust’s goal to strive to provide zero-cost abstractions.
 
 クロージャとイテレータは、関数型言語の考えに着想を得たRustの機能です。低レベルのパフォーマンスで、
 高レベルの考えを明確に表現するというRustの能力に貢献しています。クロージャとイテレータの実装は、
-実行時のパフォーマンスが影響されないようなものです。これは、ゼロ代償抽象化を提供するのに努力を惜しまないRustの目標の一部です。
+実行時のパフォーマンスが影響されないようなものです。これは、ゼロコスト抽象化を提供するのに努力を惜しまないRustの目標の一部です。
 
 <!--
 Now that we’ve improved the expressiveness of our I/O project, let’s look at


### PR DESCRIPTION
## 概要
`zero-cost abstractions`の和約が
- ゼロコスト抽象化
- ゼロ代償抽象化

の2パターンがあったため、翻訳を前者の`ゼロコスト抽象化`に統一しました。

## 変更理由
前者に統一したのは以下の理由のためです。
- 13章4節にゼロコスト抽象化とゼロ代償抽象化、それぞれの訳が登場し、翻訳として専門用語の統一をした方が良いと思われるため
- ゼロコスト抽象化の訳はイントロダクションにも登場しているため

何か私の認識に間違いがあればご指摘いただければと思います。
よろしくお願いいたします。