### PR TITLE
expect の 引数を原文を合わせる

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -432,7 +432,7 @@ use std::fs::File;
 
 fn main() {
     // hello.txtを開くのに失敗しました
-    let f = File::open("hello.txt").expect("Failed to open hello.txt");
+    let f = File::open("hello.txt").expect("hello.txt should be included in this project");
 }
 ```
 


### PR DESCRIPTION
失敗したことよりも、`should` を書いたほうがいいと、ドキュメントにも書いてあります。
https://doc.rust-lang.org/std/result/enum.Result.html#method.expect