### PR TITLE
ch04-02: 参照の借用定義を最新原文に合わせて修正

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -146,12 +146,12 @@ order to give back ownership, since we never had ownership.
 所有権をもらわないので、所有権を返す目的で値を返す必要はありません。
 
 <!--
-We call having references as function parameters *borrowing*. As in real life,
-if a person owns something, you can borrow it from them. When you’re done, you
-have to give it back.
+We call the action of creating a reference *borrowing*. As in real life, 
+if a person owns something, you can borrow it from them. When you’re done, you 
+have to give it back. You don’t own it.
 -->
 
-関数の引数に参照を取ることを*借用*と呼びます。現実生活のように、誰かが何かを所有していたら、
+参照を作成する操作を*借用*と呼びます。現実生活のように、誰かが何かを所有していたら、
 それを借りることができます。用が済んだら、返さなきゃいけないわけです。
 
 <!--

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -151,7 +151,7 @@ if a person owns something, you can borrow it from them. When you’re done, you
 have to give it back. You don’t own it.
 -->
 
-参照を作成する操作を*借用*と呼びます。現実生活のように、誰かが何かを所有していたら、
+参照を作成する行為を*借用*と呼びます。現実生活のように、誰かが何かを所有していたら、
 それを借りることができます。用が済んだら、返さなきゃいけないわけです。
 
 <!--


### PR DESCRIPTION
Closes #241

## 背景
- 既存訳では「関数の引数に参照を取ることを借用と呼びます」とあり、  
  あたかも「関数の引数限定」で借用を定義しているように誤解を招きやすい。  
- 現在の英語原文は以下のように更新されており、  
  「参照を作成する操作全般を borrowing と呼ぶ」という趣旨に変わっている。

```diff
-We call having references as function parameters *borrowing*. As in real life,
-if a person owns something, you can borrow it from them. When you’re done, you
-have to give it back.
+We call the action of creating a reference *borrowing*. As in real life, 
+if a person owns something, you can borrow it from them. When you’re done, you 
+have to give it back. You don’t own it.
```

## 変更内容
1.	日本語訳を以下のように修正
    •	旧: 関数の引数に参照を取ることを借用と呼びます。
    •	新: 参照を作成する操作を借用と呼びます。
2.	英文コメント部も最新版に更新。また原文の “You don’t own it.” を追加
