### PR TITLE
fix: ch08-02-strings のタイポを修正

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -415,7 +415,7 @@ so that this call doesn’t take ownership of any of its parameters.
 -->
 
 このコードでも、`s`は`tic-tac-toe`になります。`format!`マクロは、`println!`と似た動作をしますが、
-出力をスクリーンに行う代わりに、中身を`String`で返すのです。`format!`を使用したコードの方がはるかに読みやすく、`format!` マクロによって生成されたコードはは参照を使用するので、この呼び出しは引数の所有権を奪いません。
+出力をスクリーンに行う代わりに、中身を`String`で返すのです。`format!`を使用したコードの方がはるかに読みやすく、`format!` マクロによって生成されたコードは参照を使用するので、この呼び出しは引数の所有権を奪いません。
 
 <!--
 ### Indexing into Strings


### PR DESCRIPTION
# What

https://doc.rust-jp.rs/book-ja/ch08-02-strings.html にてタイポと思われる箇所を修正しました。

# Test

ローカルでビルドして Google Chrome にて表示したスクショを貼っておきます

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/62848bfc-0bd1-45f7-a040-5d14c44ae1b1" />


