### PR TITLE
「まえがき」ページに不自然な翻訳箇所があったため修正

### DIFF
--- a/docs/foreword.html
+++ b/docs/foreword.html
@@ -156,7 +156,7 @@ domains than you did before.
 -->
 <p>すぐにはわかりにくいかもしれませんが、Rustプログラミング言語は、エンパワーメント(empowerment)を根本原理としています:
 どんな種類のコードを現在書いているにせよ、Rustは幅広い領域で以前よりも遠くへ到達し、
-自信を持ってプログラムを組む力を与え(empower)ます。</p>
+自信を持ってプログラムを組む力を与えます。</p>
 <!--
 Take, for example, “systems-level” work that deals with low-level details of
 memory management, data representation, and concurrency. Traditionally, this
@@ -209,7 +209,7 @@ friendly and approachable text intended to help you level up not just your
 knowledge of Rust, but also your reach and confidence as a programmer in
 general. So dive in, get ready to learn—and welcome to the Rust community!
 -->
-<p>この本は、ユーザに力を与え(empower)るRustのポテンシャルを全て含んでいます。あなたのRustの知識のみをレベルアップさせるだけでなく、
+<p>この本は、ユーザに力を与えるRustのポテンシャルを全て含んでいます。あなたのRustの知識のみをレベルアップさせるだけでなく、
 プログラマとしての全般的な能力や自信をもレベルアップさせる手助けを意図した親しみやすくわかりやすいテキストです。
 さあ、飛び込んで学ぶ準備をしてください。Rustコミュニティへようこそ！</p>
 <!--


### PR DESCRIPTION
# 概要
The Rust Programming Language 日本語版 を久しぶりに読んでみようとしたところ不自然な翻訳箇所を見つけたため修正しました。

# 修正内容
文章内に不自然に登場する```empower```の単語を削除